### PR TITLE
Merge multiple dependabot PRs into a single PR

### DIFF
--- a/merge-dependabot-prs.yml
+++ b/merge-dependabot-prs.yml
@@ -1,0 +1,37 @@
+name: Merge Dependabot PRs
+
+on:
+  schedule:
+    - cron: '0 0 * * 0' # Runs weekly on Sunday at midnight
+  workflow_dispatch:
+
+jobs:
+  merge-dependabot-prs:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout main branch
+      uses: actions/checkout@v4
+      with:
+        ref: main
+
+    - name: Fetch all branches
+      run: git fetch --all
+
+    - name: Merge dependabot branches
+      run: |
+        for branch in $(git branch -r | grep dependabot); do
+          git checkout $branch
+          git merge main
+          git checkout main
+          git merge $branch
+        done
+
+    - name: Create new PR
+      uses: peter-evans/create-pull-request@v4
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        commit-message: 'Merge dependabot PRs'
+        branch: merge-dependabot-prs
+        title: 'Merge dependabot PRs'
+        body: 'This PR merges all open dependabot PRs into a single PR.'


### PR DESCRIPTION
Add a new GitHub Action workflow to merge multiple dependabot PRs into a single PR.

* Create `merge-dependabot-prs.yml` in `.github/workflows/` directory.
* Set the workflow to run weekly on Sunday at midnight.
* Checkout the main branch and fetch all branches.
* Merge all dependabot branches into the main branch.
* Create a new PR containing all the library updates from the merged dependabot PRs.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/galadril/JsonEditor?shareId=1aa2689e-cee7-4c48-805d-2aaf52313e42).