### PR TITLE
Update build version and package references

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ permissions:
   contents: write
   
 env:
-  VERSION: 1.0.7
+  VERSION: 1.0.8
 
 concurrency:
   group: ${{ github.ref }}

--- a/JsonEditor.csproj
+++ b/JsonEditor.csproj
@@ -18,18 +18,18 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Avalonia" Version="11.1.3" />
+		<PackageReference Include="Avalonia" Version="11.2.2" />
 		<PackageReference Include="Avalonia.AvaloniaEdit" Version="11.1.0" />
-		<PackageReference Include="Avalonia.Desktop" Version="11.1.3" />
-		<PackageReference Include="Avalonia.Themes.Fluent" Version="11.1.3" />
-		<PackageReference Include="Avalonia.Fonts.Inter" Version="11.1.3" />
-		<PackageReference Include="Avalonia.ReactiveUI" Version="11.1.3" />
-		<PackageReference Include="Avalonia.Xaml.Interactivity" Version="11.1.0.4" />
+		<PackageReference Include="Avalonia.Desktop" Version="11.2.2" />
+		<PackageReference Include="Avalonia.Themes.Fluent" Version="11.2.2" />
+		<PackageReference Include="Avalonia.Fonts.Inter" Version="11.2.2" />
+		<PackageReference Include="Avalonia.ReactiveUI" Version="11.2.2" />
+		<PackageReference Include="Avalonia.Xaml.Interactivity" Version="11.2.0.1" />
 
 		<!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-		<PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.1.3" />
+		<PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.2.2" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-		<PackageReference Include="ReactiveUI" Version="20.1.52" />
-		<PackageReference Include="Semi.Avalonia" Version="11.1.0.4" />
+		<PackageReference Include="ReactiveUI" Version="20.1.63" />
+		<PackageReference Include="Semi.Avalonia" Version="11.2.1.1" />
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
Update build version and package references

Updated build.yml to set VERSION to 1.0.8. Updated several package references in JsonEditor.csproj to newer versions, including Avalonia packages, ReactiveUI, and Semi.Avalonia. Some packages like Avalonia.AvaloniaEdit and Newtonsoft.Json remain unchanged.